### PR TITLE
feat: remove suspicious status to chat user

### DIFF
--- a/twitch/http.py
+++ b/twitch/http.py
@@ -1664,6 +1664,22 @@ class HTTPClient:
         body = {'user_id': target_user_id, 'status': status}
         return self.request(route, user_id=user_id, json=body)
 
+    def remove_suspicious_user_status(self,
+                                      user_id: str,
+                                      /,
+                                      broadcaster_id: str,
+                                      moderator_id: str,
+                                      target_user_id: str
+                                      ) -> Response[DataL[helix.SuspiciousUserStatus]]:
+        route = Route(
+            'DELETE',
+            'moderation/suspicious_users',
+            broadcaster_id=broadcaster_id,
+            moderator_id=moderator_id,
+            user_id=target_user_id
+        )
+        return self.request(route, user_id=user_id)
+
     def get_polls(self,
                   user_id: str,
                   /,


### PR DESCRIPTION
## What's This About?

Added the ability to remove suspicious status from the chat user endpoint, and fixed adding suspicious status to chats where it was missing a moderator ID for applications.

## Quick Checks

- [x] Actually tested this locally (it works, trust me)
- [x] Didn't break existing stuff
- [ ] Updated docs if needed
- [ ] Added tests for new features
- [x] Follows the existing code style